### PR TITLE
added deinit to remove the observer when it’s called

### DIFF
--- a/PugKitPlayground.playground/Sources/TypedNotification.swift
+++ b/PugKitPlayground.playground/Sources/TypedNotification.swift
@@ -15,6 +15,11 @@ class ObserverToken {
     fileprivate init(observer: NSObjectProtocol) {
         self.observer = observer
     }
+	
+	// remove the observer when deinit called.
+	deinit {
+		NotificationCenter.default.removeObserver(observer)
+	}
 }
 
 extension TypedNotification {


### PR DESCRIPTION
So, no need to worry about removing the observer manually. as it will be removed when deinit has called. 